### PR TITLE
renovate対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/styled-components": "5.1.15",
     "prettier": "2.3.2",
     "@types/react": "17.0.39",
-    "@types/react-dom": "17.0.13",
+    "@types/react-dom": "17.0.18",
     "@vitejs/plugin-react": "1.2.0",
     "typescript": "4.6.2",
     "vite": "2.8.6"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/styled-components": "5.1.15",
     "prettier": "2.3.2",
-    "@types/react": "17.0.39",
+    "@types/react": "18.0.25",
     "@types/react-dom": "17.0.13",
     "@vitejs/plugin-react": "1.2.0",
     "typescript": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ress": "4.0.0",
-    "styled-components": "5.3.1"
+    "styled-components": "5.3.6"
   },
   "devDependencies": {
-    "@types/styled-components": "5.1.15",
+    "@types/styled-components": "5.1.26",
     "prettier": "2.3.2",
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.13",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.13",
     "@vitejs/plugin-react": "1.2.0",
-    "typescript": "4.6.2",
+    "typescript": "4.9.3",
     "vite": "2.8.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/styled-components": "5.1.15",
     "prettier": "2.7.1",
     "@types/react": "18.0.25",
-    "@types/react-dom": "17.0.18",
+    "@types/react-dom": "18.0.11",
     "@vitejs/plugin-react": "1.3.2",
     "typescript": "4.9.3",
     "vite": "2.9.15"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "ress": "4.0.0",
+    "ress": "5.0.2",
     "styled-components": "5.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/styled-components": "5.1.15",
     "prettier": "2.3.2",
-    "@types/react": "17.0.39",
+    "@types/react": "17.0.52",
     "@types/react-dom": "17.0.13",
     "@vitejs/plugin-react": "1.2.0",
     "typescript": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "start": "npm install && vite"
   },
   "dependencies": {
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "ress": "4.0.0",
     "styled-components": "5.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@types/react-dom": "17.0.13",
     "@vitejs/plugin-react": "1.2.0",
     "typescript": "4.6.2",
-    "vite": "2.8.6"
+    "vite": "2.9.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/styled-components": "5.1.15",
-    "prettier": "2.3.2",
+    "prettier": "2.7.1",
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.13",
     "@vitejs/plugin-react": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prettier": "2.3.2",
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.13",
-    "@vitejs/plugin-react": "1.2.0",
+    "@vitejs/plugin-react": "1.3.2",
     "typescript": "4.6.2",
     "vite": "2.8.6"
   }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "prettier": "2.7.1",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.11",
-    "@vitejs/plugin-react": "1.3.2",
+    "@vitejs/plugin-react": "3.1.0",
     "typescript": "4.9.3",
-    "vite": "2.9.15"
+    "vite": "4.1.1"
   }
 }


### PR DESCRIPTION
renovate対応
#22 #23 #24 #25 #26 #27 #28 #29 #30 #31 

`@types/react-dom` は何故か対応するPRが作られていなかったので、修正する[コミット] (edbf28cc4d3d32402454da8f7bb0e16786f66ca3) を載っけています。

手元で軽くstyled-component, css modulesのサンプルを作って動かして、特に問題ないと思いました。
また、viteはrenovateで作られたもの以外に、メジャーが結構上がっていました。
そのため、動作確認ついでに上げてみましたが、問題なく動いていたので、一緒にあげました。
表面上の変化は動作するポート番号が変わるくらいです。
