### PR TITLE
chore: deny lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+save-exact=true


### PR DESCRIPTION
`.npmrc` で `ignore-scripts=true` / `save-exact=true` を追加し、 install 時の lifecycle script 実行をブロック。