### PR TITLE
chore(renovate): adopt knowledge-work/renovate-config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["local>knowledge-work/renovate-config"],
   "packageRules": [
     { "depTypeList": ["dependencies"], "groupName": "dependencies" },
     { "depTypeList": ["devDependencies"], "groupName": "devDependencies" }


### PR DESCRIPTION
extends を deprecated な \`config:base\` から \`local>knowledge-work/renovate-config\` に切り替え