### PR TITLE
chore(deps): bump vite to 8.0.14 (security fix for GHSA-v2wj-q39q-566r)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/styled-components": "5.1.36",
-    "@vitejs/plugin-react": "5.1.4",
+    "@vitejs/plugin-react": "5.2.0",
     "prettier": "3.8.1",
     "typescript": "5.9.3",
-    "vite": "7.3.1"
+    "vite": "8.0.14"
   }
 }


### PR DESCRIPTION
## Summary
脆弱性 issue knowledge-work/knowledgework#118944 で指摘された **vite 7.3.1 (GHSA-v2wj-q39q-566r)** の修正のため、`vite` を **8.0.14** に更新します。

## 変更内容

| パッケージ | 変更前 | 変更後 | 理由 |
|----------|-------|-------|------|
| `vite` | 7.3.1 | 8.0.14 | GHSA-v2wj-q39q-566r 修正 |
| `@vitejs/plugin-react` | 5.1.4 | 5.2.0 | vite 8 を peer dep でサポート |

## 注意事項

- **vite 8.x は major version up** でブレイキング変更を含みます ([Migration Guide](https://vite.dev/guide/migration))
- 本リポは lockfile を持たないため package.json のみ更新（候補者が `npm install` する想定）
- vite 8 の Node 要件: `^20.19.0 || >=22.12.0`

## Test plan
- [ ] `npm install` が通る
- [ ] `npm start` で dev server が起動する
- [ ] サンプルアプリが既存通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)