### PR TITLE
chore(deps): bulk update all packages, require Node 24+, add Renovate cooldown

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 ignore-scripts=true
 save-exact=true
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -2,22 +2,25 @@
   "name": "frontend-coding-interview",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "start": "vite"
   },
   "dependencies": {
-    "react": "19.2.4",
-    "react-dom": "19.2.4",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
     "ress": "5.0.2",
-    "styled-components": "6.3.11"
+    "styled-components": "6.4.2"
   },
   "devDependencies": {
-    "@types/react": "19.2.14",
+    "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
     "@types/styled-components": "5.1.36",
-    "@vitejs/plugin-react": "5.2.0",
-    "prettier": "3.8.1",
-    "typescript": "5.9.3",
+    "@vitejs/plugin-react": "6.0.2",
+    "prettier": "3.8.3",
+    "typescript": "6.0.3",
     "vite": "8.0.14"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["local>knowledge-work/renovate-config"],
   "packageRules": [
     { "depTypeList": ["dependencies"], "groupName": "dependencies" },
-    { "depTypeList": ["devDependencies"], "groupName": "devDependencies" }
+    { "depTypeList": ["devDependencies"], "groupName": "devDependencies" },
+    { "matchManagers": ["npm"], "minimumReleaseAge": "7 days" }
   ]
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare module 'ress'


### PR DESCRIPTION
## Summary
- 全 npm パッケージを最新化（major含む: `typescript 5.9→6.0`, `@vitejs/plugin-react 5→6`）
- `engines.node: >=24` を追加
- `renovate.json` に `minimumReleaseAge: "7 days"` を追加し、Renovate 側で npm パッケージのリリース直後の自動更新 PR を抑制
- `.npmrc` に `min-release-age=7` を追加し、npm v11+ の install 側でも同じ 7 日クールダウンを強制
- TS 6.0 で side-effect import の型解決が厳格化されたため、`vite-env.d.ts` に `declare module 'ress'` を追加

これにより以下の既存 Renovate PR を内包・置き換え:
- supersedes #62 (deps)
- supersedes #63 (devDeps)
- supersedes #64 (major devDeps)

## バージョン変更一覧

| パッケージ | 変更前 | 変更後 |
|----------|-------|-------|
| react | 19.2.4 | 19.2.6 |
| react-dom | 19.2.4 | 19.2.6 |
| styled-components | 6.3.11 | 6.4.2 |
| @types/react | 19.2.14 | 19.2.15 |
| @vitejs/plugin-react | 5.2.0 | **6.0.2** (major) |
| prettier | 3.8.1 | 3.8.3 |
| typescript | 5.9.3 | **6.0.3** (major) |

`vite` (8.0.14) / `ress` (5.0.2) / `@types/react-dom` (19.2.3) / `@types/styled-components` (5.1.36) は最新のため変更なし。

## 検証
- [x] `npm install` 成功 (0 vulnerabilities)
- [x] `npm start` → `VITE v8.0.14 ready in 558 ms`、`http://localhost:5173/` から index.html / 変換済み tsx / CSS modules すべて HTTP 200 で配信
- [x] `npx vite build` 成功 (`built in 296ms`, JS 191.43kB / CSS 2.68kB)
- [x] `npx tsc --noEmit` 成功（`ress` の declare 追加後）

## 注意事項
- lockfile は引き続きコミットしない方針（候補者が `npm install` する想定）
- 検証は Node 22.18 / npm 10.9.3 で実施（`min-release-age` は無視される）。Node 24 / npm 11+ では `min-release-age=7` が効くため、`vite@8.0.14`（公開 2026-05-21、本日時点で 5 日経過）や `styled-components@6.4.2`（同 7 日）の install が一時的に弾かれる可能性があります。merge を 2〜3 日後ろにずらすか、初回は `npm install --ignore-min-release-age` で対応してください
- engines は警告のみ（npm `engine-strict` は未設定）。厳格化したい場合は `.npmrc` に `engine-strict=true` を追加可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)